### PR TITLE
updated script/deploy file to deploy to github instead of heroku

### DIFF
--- a/script/deploy
+++ b/script/deploy
@@ -23,7 +23,7 @@ set -e
 function cleanup_at_exit {
   # return to your master branch
   git checkout master
-  
+
   # remove the deploy branch
   git branch -D deploy
 }
@@ -43,4 +43,7 @@ git add -f public/bundle.js public/bundle.js.map
 git commit --allow-empty -m 'Deploying'
 
 # push your local "deploy" branch to the "master" branch on heroku
-git push --force heroku deploy:master
+# git push --force heroku deploy:master
+# pushing code to 'deploy' branch which has a web hook between github and heroku
+# anything pushed to 'deploy' branch will be deployed to heroku server
+git push --force deploy


### PR DESCRIPTION
Previously, the deploy script used heroku but I set up a web hook between the deploy branch on GitHub and heroku
I propose we use this deploy branch so that deploy can be performed without heroku installed locally